### PR TITLE
Add pyproject.toml for uv/pip install support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,16 +39,15 @@ if(UNIX)
     target_include_directories(xrobotoolkit_sdk PUBLIC
         ${PROJECT_SOURCE_DIR}/include
     )
-    target_link_directories(xrobotoolkit_sdk PUBLIC ${PROJECT_SOURCE_DIR}/lib)
+    target_link_directories(xrobotoolkit_sdk PUBLIC ${PROJECT_SOURCE_DIR}/lib /opt/apps/roboticsservice/SDK/x64)
   endif()
   target_link_libraries(xrobotoolkit_sdk PUBLIC
       PXREARobotSDK
   )
+  set_target_properties(xrobotoolkit_sdk PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH /opt/apps/roboticsservice/SDK/x64)
 endif()
 
 # Install the Python module
 install(TARGETS xrobotoolkit_sdk
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} # Installs to <prefix>/lib
-                                                # You might want a Python-specific path like:
-                                                # DESTINATION lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages
+    LIBRARY DESTINATION . # Installs to wheel root for uv/pip
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["scikit-build-core>=0.8", "pybind11>=2.11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "xrobotoolkit_sdk"
+version = "1.0.2"
+requires-python = ">=3.10"
+
+[tool.scikit-build]
+wheel.install-dir = "."


### PR DESCRIPTION
This PR enables installing `xrobotoolkit_sdk` via `uv` or `pip`.

### Prerequisites

Install XRoboToolkit-PC-Service via `.deb` package:

```bash
sudo dpkg -i XRoboToolkit_PC_Service_1.0.0_ubuntu_22.04_amd64.deb
```

### Example: Adding to XRoboToolkit-Teleop-Sample-Python

```bash
git clone https://github.com/XR-Robotics/XRoboToolkit-Teleop-Sample-Python.git
cd XRoboToolkit-Teleop-Sample-Python
uv sync
uv add "xrobotoolkit-sdk @ git+https://github.com/XR-Robotics/XRoboToolkit-PC-Service-Pybind.git@refs/pull/14/head"
uv run python -c "import xrobotoolkit_sdk; print('success')"
```

You can also add the dependency directly to `pyproject.toml`:

```
[project]
dependencies = [
    "xrobotoolkit-sdk @ git+https://github.com/XR-Robotics/XRoboToolkit-PC-Service-Pybind.git@refs/pull/14/head",
]
```

Then run:

```bash
uv sync
```